### PR TITLE
Make honeypot field invisible via inline style

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ Example:
 </html>
 ```
 
+#### `Honeypot::getHiddenField($name = null)`
+
+This static method generates the input field just like `getField()` does, but adds inline CSS to hide the field directly. Note: This may be easier to detect for some bots.
+If you want to get creative with hiding the field, use `getField()` in combination with custom CSS (or JS).
+
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/src/Honeypot.php
+++ b/src/Honeypot.php
@@ -34,6 +34,16 @@ class Honeypot implements MiddlewareInterface
     }
 
     /**
+     * Build a new honeypot field, hidden via inline CSS.
+     */
+    public static function getHiddenField(string $name = null): string
+    {
+        $name = $name ?: self::$currentName;
+
+        return sprintf('<input type="text" name="%s" style="display: none">', $name);
+    }
+
+    /**
      * Set the field name.
      */
     public function __construct(string $name = 'hpt_name')

--- a/tests/HoneypotTest.php
+++ b/tests/HoneypotTest.php
@@ -46,5 +46,8 @@ class HoneypotTest extends TestCase
     {
         $this->assertEquals('<input type="text" name="hpt_name">', Honeypot::getField());
         $this->assertEquals('<input type="text" name="foo">', Honeypot::getField('foo'));
+
+        $this->assertEquals('<input type="text" name="hpt_name" style="display: none">', Honeypot::getHiddenField());
+        $this->assertEquals('<input type="text" name="foo" style="display: none">', Honeypot::getHiddenField('foo'));
     }
 }


### PR DESCRIPTION
This should simplify the usage of this nice little library. :)